### PR TITLE
Add base64 document handling to serializer

### DIFF
--- a/netbox_documents/api/fields.py
+++ b/netbox_documents/api/fields.py
@@ -1,0 +1,7 @@
+from drf_extra_fields.fields import Base64FileField
+
+class UploadableBase64FileField(Base64FileField):
+    ALLOWED_TYPES = ['']
+    
+    def get_file_extension(self, filename, decoded_file):
+        return ''

--- a/netbox_documents/api/serializers.py
+++ b/netbox_documents/api/serializers.py
@@ -4,6 +4,7 @@ from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializ
 from ..models import SiteDocument, DeviceDocument, DeviceTypeDocument, CircuitDocument 
 from dcim.api.nested_serializers import NestedSiteSerializer, NestedDeviceSerializer, NestedDeviceTypeSerializer 
 from circuits.api.nested_serializers import NestedCircuitSerializer
+from .fields import UploadableBase64FileField
 
 # Site Document Serializer
 class SiteDocumentSerializer(NetBoxModelSerializer):
@@ -13,6 +14,7 @@ class SiteDocumentSerializer(NetBoxModelSerializer):
     )
 
     site = NestedSiteSerializer()
+    document = UploadableBase64FileField(required=False)
 
     class Meta:
         model = SiteDocument
@@ -42,6 +44,7 @@ class DeviceDocumentSerializer(NetBoxModelSerializer):
     )
 
     device = NestedDeviceSerializer()
+    document = UploadableBase64FileField(required=False)
 
     class Meta:
         model = DeviceDocument
@@ -70,6 +73,7 @@ class DeviceTypeDocumentSerializer(NetBoxModelSerializer):
     )
 
     device_type = NestedDeviceTypeSerializer()
+    document = UploadableBase64FileField(required=False)
 
     class Meta:
         model = DeviceTypeDocument
@@ -86,6 +90,7 @@ class CircuitDocumentSerializer(NetBoxModelSerializer):
     )
 
     circuit = NestedCircuitSerializer()
+    document = UploadableBase64FileField(required=False)
 
     class Meta:
         model = CircuitDocument

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+drf_extra_fields>=3.7.0


### PR DESCRIPTION
This fixes #38 (at least in sort of a different way).  It does have an external dependency and it probably needs some documentation someplace.  I can write that, please let me know where it should go.  I didn't know if the main README was appropriate.