### PR TITLE
Correct typo in verbose name

### DIFF
--- a/netbox_documents/migrations/0004_correct_verbose_plural.py
+++ b/netbox_documents/migrations/0004_correct_verbose_plural.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("netbox_documents", "0003_alter_circuitdocument_options_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="circuitdocument",
+            options={
+                "verbose_name_plural": "Circuit Documents",
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="devicedocument",
+            options={
+                "verbose_name_plural": "Device Documents",
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="devicetypedocument",
+            options={
+                "verbose_name_plural": "Device Type Documents",
+            },
+        ),
+        migrations.AlterModelOptions(
+            name="sitedocument",
+            options={
+                "verbose_name_plural": "Site Documents",
+            },
+        )
+    ]

--- a/netbox_documents/models.py
+++ b/netbox_documents/models.py
@@ -91,7 +91,7 @@ class SiteDocument(NetBoxModel):
 
     class Meta:
         ordering = ('-created', 'name')
-        verbose_name_plural = "Site Documments"
+        verbose_name_plural = "Site Documents"
         verbose_name = "Site Document"
 
     def get_document_type_color(self):
@@ -201,7 +201,7 @@ class DeviceDocument(NetBoxModel):
 
     class Meta:
         ordering = ('name',)
-        verbose_name_plural = "Device Documments"
+        verbose_name_plural = "Device Documents"
         verbose_name = "Device Document"
 
     def get_document_type_color(self):
@@ -307,7 +307,7 @@ class DeviceTypeDocument(NetBoxModel):
 
     class Meta:
         ordering = ('name',)
-        verbose_name_plural = "Device Type Documments"
+        verbose_name_plural = "Device Type Documents"
         verbose_name = "Device Type Document"
 
     def get_document_type_color(self):
@@ -415,7 +415,7 @@ class CircuitDocument(NetBoxModel):
 
     class Meta:
         ordering = ('name',)
-        verbose_name_plural = "Circuit Documments"
+        verbose_name_plural = "Circuit Documents"
         verbose_name = "Circuit Document"
 
     @property


### PR DESCRIPTION
This fixes #39.  Just a typo.