### PR TITLE
Fixed files for Netbox 4.0 Compliance

### DIFF
--- a/netbox_documents/__init__.py
+++ b/netbox_documents/__init__.py
@@ -1,4 +1,4 @@
-from extras.plugins import PluginConfig
+from netbox.plugins import PluginConfig
 
 class NetboxDocuments(PluginConfig):
     name = 'netbox_documents'

--- a/netbox_documents/navigation.py
+++ b/netbox_documents/navigation.py
@@ -1,5 +1,4 @@
 from extras.plugins import PluginMenuItem, PluginMenu, PluginMenuButton
-from utilities.choices import ButtonColorChoices
 from django.conf import settings
 
 plugin_settings = settings.PLUGINS_CONFIG.get('netbox_documents', {})
@@ -18,7 +17,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:sitedocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -33,7 +31,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:locationdocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -48,7 +45,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:devicedocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -63,7 +59,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:devicetypedocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -78,7 +73,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:circuitdocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -104,7 +98,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:vmdocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )
@@ -119,7 +112,6 @@ if plugin_settings.get('enable_navigation_menu'):
                     link='plugins:netbox_documents:circuitproviderdocument_add',
                     title='Add',
                     icon_class='mdi mdi-plus-thick',
-                    color=ButtonColorChoices.GREEN
                 )]
             )
         )

--- a/netbox_documents/template_content.py
+++ b/netbox_documents/template_content.py
@@ -1,4 +1,4 @@
-from extras.plugins import PluginTemplateExtension
+from netbox.plugins import PluginTemplateExtension
 from django.conf import settings
 from .models import SiteDocument, LocationDocument, DeviceDocument, DeviceTypeDocument, CircuitDocument, VMDocument, CircuitProviderDocument
 


### PR DESCRIPTION
I changed extras.plugins to netbox.plugins  for the following files:
in __init__.py 
template_content.py

I also removed the button color (as it is no longer supported) for the following file:
navigation.py

Documentation for performing these tasks I found here: 
https://netboxlabs.com/docs/netbox/en/stable/plugins/development/migration-v4/ 

I have never contributed to a Github repo before, so I hope I helped, and this is sufficient.