### PR TITLE
Fix DocTypeChoices has no attribute choices

### DIFF
--- a/netbox_documents/forms.py
+++ b/netbox_documents/forms.py
@@ -26,7 +26,7 @@ class DocumentForm(NetBoxModelForm):
         allowed_values = get_allowed_doc_types(content_type_id)
 
         if allowed_values is not None:
-            all_choices = list(DocTypeChoices.choices)
+            all_choices = list(DocTypeChoices())
             filtered = [c for c in all_choices if c[0] in allowed_values]
 
             # Preserve the current value when editing an existing document


### PR DESCRIPTION
Instantiating the class (DocTypeChoices()) triggers the iterator, which returns the final, merged list of tuples.

P.S: I don't know if this affects compatibility with Netbox < 4.5

Fixes #92