### PR TITLE
Restore add button in both sidebar and main plugin page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.8.3 (2026-05-07)
+* Restore the Add button in the sidebar and in the main Documents page.
+
 ## 0.8.2 (2026-02-13)
 
 * Fix stale ContentType entries from old per-model document tables causing ProtectedError during NetBox upgrades

--- a/netbox_documents/__init__.py
+++ b/netbox_documents/__init__.py
@@ -5,7 +5,7 @@ class NetboxDocuments(PluginConfig):
     name = 'netbox_documents'
     verbose_name = 'Document Storage'
     description = 'Attach documents and external URLs to any NetBox object'
-    version = '0.8.2'
+    version = '0.8.3'
     author = 'Jason Yates'
     author_email = 'me@jasonyates.co.uk'
     min_version = '4.3.0'

--- a/netbox_documents/navigation.py
+++ b/netbox_documents/navigation.py
@@ -11,6 +11,15 @@ if plugin_settings.get('enable_navigation_menu'):
             link='plugins:netbox_documents:document_list',
             link_text='Documents',
             permissions=["netbox_documents.view_document"],
+            buttons=[
+                PluginMenuButton(
+                    link='plugins:netbox_documents:document_add',
+                    title='Add',
+                    icon_class='mdi mdi-plus-thick',
+                    permissions=['netbox_documents.add_document'],
+                    color=ButtonColorChoices.GREEN,
+                ),
+            ],
         )
     ]
 

--- a/netbox_documents/views.py
+++ b/netbox_documents/views.py
@@ -15,6 +15,7 @@ class DocumentListView(generic.ObjectListView):
     filterset = filtersets.DocumentFilterSet
     filterset_form = forms.DocumentFilterForm
     actions = {
+        'add': {'add'},
         'export': {'view'},
         'bulk_delete': {'delete'},
     }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(top_level_directory, 'requirements.txt')) as file:
 
 setup(
     name='netbox-documents',
-    version='0.8.2',
+    version='0.8.3',
     description='Attach documents and external URLs to any NetBox object',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
I took the liberty of re-adding the Add button on the sidebar and on the plugin page. I'm not certain when exactly they've gone missing, but the intended behavior is likely to have them.