### PR TITLE
Skip rendering without allowed choices

### DIFF
--- a/netbox_documents/template_content.py
+++ b/netbox_documents/template_content.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from netbox.plugins import PluginTemplateExtension
 from django.conf import settings
-from .models import Document
+from .models import Document, get_allowed_doc_types
 
 plugin_settings = settings.PLUGINS_CONFIG.get('netbox_documents', {})
 
@@ -37,6 +37,10 @@ def _make_extension(model_label):
         def _render_panel(self):
             obj = self.context['object']
             ct = ContentType.objects.get_for_model(obj)
+
+            if not get_allowed_doc_types(ct.pk):
+                return ''
+
             return self.render('netbox_documents/document_include.html', extra_context={
                 'documents': self._get_documents(),
                 'content_type_id': ct.pk,


### PR DESCRIPTION
When setting object types under "allowed_doc_types" to an empty list to avoid the addition of documents for them, the box would be rendered but with an empty list of choices upon trying to add new documents, which might be confusing to users or give the impression of a bug. Instead, avoid rendering of the box completely if no document types are allowed.
This also allows setting "__all__" to an empty list if document storage is only desired for selected object types.