### PR TITLE
Simplify migration dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin designed to facilitate the storage of documents against any object with
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
+|     4.6+       |      0.8.3     |
 |     4.3+       |      0.8.2     |
 |     4.3+       |      0.7.4     |
 |     4.2+       |      0.7.2     |

--- a/netbox_documents/migrations/0009_document.py
+++ b/netbox_documents/migrations/0009_document.py
@@ -8,8 +8,8 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '__latest__'),
-        ('extras', '__latest__'),
+        ('contenttypes', '__first__'),
+        ('extras', '__first__'),
         ('netbox_documents', '0008_moduletypedocument'),
     ]
 

--- a/netbox_documents/migrations/0010_migrate_data.py
+++ b/netbox_documents/migrations/0010_migrate_data.py
@@ -130,9 +130,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('netbox_documents', '0009_document'),
-        ('contenttypes', '__latest__'),
-        ('extras', '__latest__'),
-        ('core', '__latest__'),
     ]
 
     operations = [

--- a/netbox_documents/migrations/0012_cleanup_stale_contenttypes.py
+++ b/netbox_documents/migrations/0012_cleanup_stale_contenttypes.py
@@ -100,9 +100,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('netbox_documents', '0011_remove_old_models'),
-        ('contenttypes', '__latest__'),
-        ('extras', '__latest__'),
-        ('core', '__latest__'),
     ]
 
     operations = [


### PR DESCRIPTION
It seems 0010 and 0012 do not actually modify any core NetBox models, and hence do not need a dependency. For 0009 the modified models seem to already exist in the first squashed migration as of 4.6.

This solves InconsistentMigrationHistory during upgrades.

---

I did not test any older versions of NetBox!