### PR TITLE
Update changelog and compatibility table for 0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
-## 0.8.3 (2026-05-07)
-* Restore the Add button in the sidebar and in the main Documents page.
+## 0.8.3 (2026-07-02)
+
+* Fix InconsistentMigrationHistory errors when upgrading NetBox by removing `__latest__` migration dependencies - PR #102 (Thanks @tacerus) (Fixes #98, #103)
+* Fix exception on Add Document when `allowed_doc_types` is configured - PR #96 (Thanks @shumbashi) (Fixes #92)
+* Skip rendering the documents panel when a model has no allowed document types - PR #99 (Thanks @tacerus)
+* Restore the Add button in the sidebar and in the main Documents page - PR #97 (Thanks @a084ed22)
+* Fix contributing/test instructions - PR #100 (Thanks @tacerus)
 
 ## 0.8.2 (2026-02-13)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A plugin designed to facilitate the storage of documents against any object with
 | NetBox Version | Plugin Version |
 |----------------|----------------|
 |     4.6+       |      0.8.3     |
-|     4.3+       |      0.8.2     |
+|     4.5+       |      0.8.2     |
 |     4.3+       |      0.7.4     |
 |     4.2+       |      0.7.2     |
 |  4.0 - 4.1     |      0.7.0     |


### PR DESCRIPTION
Updates the 0.8.3 changelog entry to cover all merged fixes (#96, #97, #99, #100, #102) with contributor credits, and corrects the 0.8.2 compatibility row to NetBox 4.5+ (0.8.2 imports `netbox.api.gfk_fields`, which does not exist before 4.5 - see #94).