### PR TITLE
Update document panels to match current NetBox card UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Update the documents panel and document detail page to match the current NetBox card UI - the Add button now appears as a header action (Thanks @julianstolp) (Fixes #93)
+
 ## 0.8.3 (2026-07-02)
 
 * Fix InconsistentMigrationHistory errors when upgrading NetBox by removing `__latest__` migration dependencies - PR #102 (Thanks @tacerus) (Fixes #98, #103)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 0.8.4 (2026-07-02)
 
 * Update the documents panel and document detail page to match the current NetBox card UI - the Add button now appears as a header action (Thanks @julianstolp) (Fixes #93)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A plugin designed to facilitate the storage of documents against any object with
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
+|     4.6+       |      0.8.4     |
 |     4.6+       |      0.8.3     |
 |     4.5+       |      0.8.2     |
 |     4.3+       |      0.7.4     |

--- a/netbox_documents/__init__.py
+++ b/netbox_documents/__init__.py
@@ -5,7 +5,7 @@ class NetboxDocuments(PluginConfig):
     name = 'netbox_documents'
     verbose_name = 'Document Storage'
     description = 'Attach documents and external URLs to any NetBox object'
-    version = '0.8.3'
+    version = '0.8.4'
     author = 'Jason Yates'
     author_email = 'me@jasonyates.co.uk'
     min_version = '4.3.0'

--- a/netbox_documents/templates/netbox_documents/document.html
+++ b/netbox_documents/templates/netbox_documents/document.html
@@ -6,7 +6,7 @@
   <div class="row mb-3">
     <div class="col col-md-6">
       <div class="card">
-        <h5 class="card-header">Document</h5>
+        <h2 class="card-header">Document</h2>
         <div class="card-body">
           <table class="table table-hover attr-table">
             <tr>

--- a/netbox_documents/templates/netbox_documents/document_include.html
+++ b/netbox_documents/templates/netbox_documents/document_include.html
@@ -1,9 +1,18 @@
 {% load helpers %}
 
 <div class="card">
-<h5 class="card-header">
+<h2 class="card-header">
     Documents
-</h5>
+    {% if perms.netbox_documents.add_document %}
+        <div class="card-actions">
+            <a class="btn btn-ghost-primary btn-sm"
+                href="{% url 'plugins:netbox_documents:document_add' %}?content_type={{ content_type_id }}&object_id={{ object.pk }}&return_url={{ return_url }}">
+                <i aria-hidden="true" class="mdi mdi-plus-thick"></i>
+                Attach a document
+            </a>
+        </div>
+    {% endif %}
+</h2>
 <div class="card-body">
 {% if documents %}
     <table class="table table-hover">
@@ -46,13 +55,4 @@
         </div>
     {% endif %}
     </div>
-    {% if perms.netbox_documents.add_document %}
-        <div class="card-footer text-end noprint">
-            <a href="{% url 'plugins:netbox_documents:document_add' %}?content_type={{ content_type_id }}&object_id={{ object.pk }}&return_url={{ return_url }}" class="btn btn-primary btn-sm">
-                <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
-                Add Document
-            </a>
-        </div>
-    {% endif %}
-
 </div>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(top_level_directory, 'requirements.txt')) as file:
 
 setup(
     name='netbox-documents',
-    version='0.8.3',
+    version='0.8.4',
     description='Attach documents and external URLs to any NetBox object',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Implements the suggestion from #93: the documents panel now uses the modern NetBox card style, with the add button moved into the card header as a ghost-button action and the card footer removed. Applies the same header style to the document detail page.

Fixes #93