### PR TITLE
Fix server error when adding a document outside an object page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.5 (2026-07-02)
+
+* Fix server error (IntegrityError) when adding a document from the sidebar or Documents list page - documents must be added from an object's detail page, so the standalone Add buttons introduced in 0.8.3 have been removed (Fixes #107)
+* Raise a validation error instead of a server error if a document is saved without an associated object
+
 ## 0.8.4 (2026-07-02)
 
 * Update the documents panel and document detail page to match the current NetBox card UI - the Add button now appears as a header action (Thanks @julianstolp) (Fixes #93)

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ A plugin designed to facilitate the storage of documents against any object with
 
 | NetBox Version | Plugin Version |
 |----------------|----------------|
-|     4.6+       |      0.8.4     |
-|     4.6+       |      0.8.3     |
+|     4.6+       |      0.8.5     |
 |     4.5+       |      0.8.2     |
 |     4.3+       |      0.7.4     |
 |     4.2+       |      0.7.2     |

--- a/netbox_documents/__init__.py
+++ b/netbox_documents/__init__.py
@@ -5,7 +5,7 @@ class NetboxDocuments(PluginConfig):
     name = 'netbox_documents'
     verbose_name = 'Document Storage'
     description = 'Attach documents and external URLs to any NetBox object'
-    version = '0.8.4'
+    version = '0.8.5'
     author = 'Jason Yates'
     author_email = 'me@jasonyates.co.uk'
     min_version = '4.3.0'

--- a/netbox_documents/models.py
+++ b/netbox_documents/models.py
@@ -165,6 +165,11 @@ class Document(NetBoxModel):
 
     def clean(self):
         super().clean()
+        if self.content_type_id is None or self.object_id is None:
+            raise ValidationError(
+                "A document must be associated with an object. Add documents from the detail page "
+                "of the object they relate to."
+            )
         if not self.document and self.external_url == '':
             raise ValidationError("A document must contain an uploaded file or an external URL.")
         if self.document and self.external_url:

--- a/netbox_documents/navigation.py
+++ b/netbox_documents/navigation.py
@@ -1,5 +1,4 @@
-from netbox.plugins import PluginMenuItem, PluginMenu, PluginMenuButton
-from netbox.choices import ButtonColorChoices
+from netbox.plugins import PluginMenuItem, PluginMenu
 from django.conf import settings
 
 plugin_settings = settings.PLUGINS_CONFIG.get('netbox_documents', {})
@@ -11,15 +10,6 @@ if plugin_settings.get('enable_navigation_menu'):
             link='plugins:netbox_documents:document_list',
             link_text='Documents',
             permissions=["netbox_documents.view_document"],
-            buttons=[
-                PluginMenuButton(
-                    link='plugins:netbox_documents:document_add',
-                    title='Add',
-                    icon_class='mdi mdi-plus-thick',
-                    permissions=['netbox_documents.add_document'],
-                    color=ButtonColorChoices.GREEN,
-                ),
-            ],
         )
     ]
 

--- a/netbox_documents/views.py
+++ b/netbox_documents/views.py
@@ -15,7 +15,6 @@ class DocumentListView(generic.ObjectListView):
     filterset = filtersets.DocumentFilterSet
     filterset_form = forms.DocumentFilterForm
     actions = {
-        'add': {'add'},
         'export': {'view'},
         'bulk_delete': {'delete'},
     }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(top_level_directory, 'requirements.txt')) as file:
 
 setup(
     name='netbox-documents',
-    version='0.8.4',
+    version='0.8.5',
     description='Attach documents and external URLs to any NetBox object',
     long_description=long_description,
     long_description_content_type='text/markdown',


### PR DESCRIPTION
Removes the standalone Add buttons (sidebar and Documents list page) reintroduced in 0.8.3 - the document form has no object selector, so these always failed with an IntegrityError. Also adds model validation so a document without an assigned object returns a form error instead of a server error.

Fixes #107